### PR TITLE
Feat: add neat keybindings for fuzzy-finding

### DIFF
--- a/plugins.vim
+++ b/plugins.vim
@@ -29,6 +29,8 @@ call plug#end()
 
 " Mappings
 nnoremap <C-p> <cmd>Telescope git_files<cr>
+nnoremap <C-f> <cmd>Telescope current_buffer_fuzzy_find<cr>
+nnoremap <C-,> <cmd>lua require'telescope.builtin'.find_files({ cwd = vim.fn.stdpath('config') })<CR>
 nnoremap <C-b> <cmd>NERDTreeToggle<cr>
 
 " Set colorscheme


### PR DESCRIPTION
This PR adds some neat key mappings using Telescope's built-in [current buffer fuzzy finder](https://github.com/nvim-telescope/telescope.nvim#vim-pickers). The shortcut would be `<C-f>`.

Another one that was added was the ability to fuzzy find over the files in the configuration directory. It uses the [`vim.fn.stdpath('config')`](https://neovim.io/doc/user/lua.html#vim.fn) function from the Lua API to dynamically find the configuration directory. The shortcut would be `<C-,>`, mostly inspired by VS Code's shortcut.